### PR TITLE
When forwarding a request, do not forward to self.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- When forwarding a request, do not forward to self.
+
 ## [1.7.4] - 2022-06-21
 
 ### Fixed

--- a/dotnet/Services/VtexAPIService.cs
+++ b/dotnet/Services/VtexAPIService.cs
@@ -966,6 +966,12 @@ namespace AvailabilityNotify.Services
             if (!string.IsNullOrEmpty(accountName))
             {
                 accountName = accountName.Trim();
+                if (_context.Vtex.Account.Equals(accountName, StringComparison.OrdinalIgnoreCase))
+                {
+                    _context.Vtex.Logger.Warn("ForwardNotification", null, $"Skipping self reference.  Please remove account from app settings.");
+                    return true;
+                }
+                
                 AffiliateNotification affiliateNotification = new AffiliateNotification
                 {
                     An = notification.An,


### PR DESCRIPTION
If an account tries to forward a request to itself, it causes a timeout.