### PR TITLE
[NOTIFIER-56] Fix/process unset notifications test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- (NOTIFIER-56) Fix processUnsentRequests mutation response.
+
 ## [1.8.4] - 2022-07-27
 
 ### Changed

--- a/dotnet/GraphQL/Mutation.cs
+++ b/dotnet/GraphQL/Mutation.cs
@@ -60,7 +60,7 @@ namespace AvailabilityNotify.GraphQL
                     return await availabilityRepository.DeleteNotifyRequest(id);
                 });
             
-            FieldAsync<ListGraphType<StringGraphType>>(
+            FieldAsync<ListGraphType<ProcessingResultType>>(
                 "processUnsentRequests",
                 resolve: async context =>
                 {

--- a/dotnet/GraphQL/Types/ProcessingResultType.cs
+++ b/dotnet/GraphQL/Types/ProcessingResultType.cs
@@ -1,0 +1,26 @@
+using AvailabilityNotify.Models;
+using GraphQL;
+using GraphQL.Types;
+
+        // public string SkuId { get; set; }
+        // public string QuantityAvailable { get; set; }
+        // public string Email { get; set; }
+        // public bool Sent { get; set; }
+        // public bool Updated { get; set; }
+
+namespace AvailabilityNotify.GraphQL.Types
+{
+    [GraphQLMetadata("ProcessingResult")]
+    public class ProcessingResultType : ObjectGraphType<ProcessingResult>
+    {
+        public ProcessingResultType()
+        {
+            Name = "ProcessingResult";
+            Field(c => c.SkuId, type: typeof(StringGraphType)).Description("SkuId");
+            Field(c => c.QuantityAvailable, type: typeof(StringGraphType)).Description("QuantityAvailable");
+            Field(c => c.Sent, type: typeof(StringGraphType)).Description("Sent");
+            Field(c => c.Email, type: typeof(StringGraphType)).Description("Email");
+            Field(c => c.Updated, type: typeof(StringGraphType)).Description("Updated");
+        }
+    }
+}

--- a/dotnet/GraphQL/Types/ProcessingResultType.cs
+++ b/dotnet/GraphQL/Types/ProcessingResultType.cs
@@ -17,10 +17,10 @@ namespace AvailabilityNotify.GraphQL.Types
         {
             Name = "ProcessingResult";
             Field(c => c.SkuId, type: typeof(StringGraphType)).Description("SkuId");
-            Field(c => c.QuantityAvailable, type: typeof(StringGraphType)).Description("QuantityAvailable");
-            Field(c => c.Sent, type: typeof(StringGraphType)).Description("Sent");
             Field(c => c.Email, type: typeof(StringGraphType)).Description("Email");
-            Field(c => c.Updated, type: typeof(StringGraphType)).Description("Updated");
+            Field(c => c.QuantityAvailable, type: typeof(StringGraphType)).Description("QuantityAvailable");
+            Field(c => c.Sent, type: typeof(BooleanGraphType)).Description("Sent");
+            Field(c => c.Updated, type: typeof(BooleanGraphType)).Description("Updated");
         }
     }
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -22,8 +22,9 @@ type Query {
 type ProcesingResult {
   skuId: String
   email: String
-  sent: String
-  updated: String
+  quantityAvailable: String
+  sent: Boolean
+  updated: Boolean
 }
 
 type NotifyRequest {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -8,15 +8,22 @@ type Mutation {
     locale: String
     sellerObj: SellerObjInputType!
   ): Boolean
-  deleteRequest(id: String): Boolean @cacheControl(scope: PRIVATE)
 
-  processUnsentRequests: [NotifyRequest] @cacheControl(scope: PRIVATE)
+  deleteRequest(id: String): Boolean @cacheControl(scope: PRIVATE)
+  processUnsentRequests: [ProcesingResult] @cacheControl(scope: PRIVATE)
 }
 
 # Queries
 
 type Query {
   listRequests: [NotifyRequest]
+}
+
+type ProcesingResult {
+  skuId: String
+  email: String
+  sent: String
+  updated: String
 }
 
 type NotifyRequest {

--- a/react/graphql/processUnsentRequests.gql
+++ b/react/graphql/processUnsentRequests.gql
@@ -2,6 +2,7 @@ mutation ProcessUnsentRequests {
   processUnsentRequests @context(provider: "vtex.availability-notify") {
     skuId
     email
+    quantityAvailable
     sent
     updated
   }

--- a/react/graphql/processUnsentRequests.gql
+++ b/react/graphql/processUnsentRequests.gql
@@ -1,3 +1,8 @@
 mutation ProcessUnsentRequests {
-  processUnsentRequests @context(provider: "vtex.availability-notify")
+  processUnsentRequests @context(provider: "vtex.availability-notify") {
+    skuId
+    email
+    sent
+    updated
+  }
 }


### PR DESCRIPTION
## What was made in this PR?

The mutation ProcessUnsentRequest didn't have it's own type graphql in the dotnet folder, and neither in the main graphql schema.

[Worskpace to test](https://restrules--sandboxusdev.myvtex.com/_v/private/vtex.availability-notify@1.8.4/graphiql/v1?query=mutation%0A%7B%0A%20%20processUnsentRequests%0A%20%20%7B%0A%20%20%20%20skuId%0A%20%20%20%20sent%0A%20%20%20%20quantityAvailable%0A%20%20%7D%0A%7D)