### PR TITLE
Consider unlimited inventory as in-stock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Consider unlimited inventory as in-stock
+
 ## [1.9.0] - 2022-12-23
 
 ### Fixed


### PR DESCRIPTION
Previously locations with unlimited inventory were skipped when calculating available inventory.  Changed to consider unlimited inventory as in-stock.