### PR TITLE
Allow non vtex emails to save app settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow non VTEX emails to save app settings, as it was throwing a 403 error when trying to perform this operation
+
 ## [1.11.3] - 2023-08-17
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "vtex.address-form": "4.x",
-    "vtex.apps-graphql": "2.x",
+    "vtex.apps-graphql": "3.x",
     "vtex.checkout-resources": "0.x",
     "vtex.css-handles": "1.x",
     "vtex.device-detector": "0.x",


### PR DESCRIPTION
Currently with the. older version of vtex.apps-graphql@2.x it is not possible for non vtex emails to save the app settings. Changing the version of this app to 3.x fixes this error.