### PR TITLE
[STR-1076] Add admin warning about upcoming License Manager permission requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Warning message in the admin panel informing that Download Requests and Process Unsent will require a License Manager resource starting on a date to be defined.
+
 ## [1.14.2] - 2026-05-05
 
 ### Fixed

--- a/messages/en.json
+++ b/messages/en.json
@@ -19,5 +19,5 @@
   "admin/settings.verify-availability-helptext": "Runs a shipping simulation to verify that the item can be shipped to the shopper before sending a notification.",
   "admin/settings.marketplace-to-notify-helptext": "Allows a seller account to specify a comma separated list of marketplace account names to notify of inventory updates.",
   "admin/settings.label": "Settings",
-  "admin/settings.permission-warning": "Starting dd/mm/yyyy, accessing Download Requests and Process Unsent will require the [resource-name] resource in License Manager. Make sure the users who need this feature have the appropriate role assigned."
+  "admin/settings.permission-warning": "Starting dd/mm/yyyy, accessing Download Requests and Process Unsent will require the Download Notification Requests resource in License Manager. Make sure the users who need this feature have the appropriate role assigned."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -18,5 +18,6 @@
   "admin/settings.process-unsent-helptext": "Process all unsent requests to notify and download an XLS file of the results.",
   "admin/settings.verify-availability-helptext": "Runs a shipping simulation to verify that the item can be shipped to the shopper before sending a notification.",
   "admin/settings.marketplace-to-notify-helptext": "Allows a seller account to specify a comma separated list of marketplace account names to notify of inventory updates.",
-  "admin/settings.label": "Settings"
+  "admin/settings.label": "Settings",
+  "admin/settings.permission-warning": "Starting dd/mm/yyyy, accessing Download Requests and Process Unsent will require the [resource-name] resource in License Manager. Make sure the users who need this feature have the appropriate role assigned."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -19,5 +19,5 @@
   "admin/settings.verify-availability-helptext": "Runs a shipping simulation to verify that the item can be shipped to the shopper before sending a notification.",
   "admin/settings.marketplace-to-notify-helptext": "Allows a seller account to specify a comma separated list of marketplace account names to notify of inventory updates.",
   "admin/settings.label": "Settings",
-  "admin/settings.permission-warning": "Starting dd/mm/yyyy, accessing Download Requests and Process Unsent will require the Download Notification Requests resource in License Manager. Make sure the users who need this feature have the appropriate role assigned."
+  "admin/settings.permission-warning": "Starting 09/21/2026, accessing Download Requests and Process Unsent will require the Download Notification Requests resource in License Manager. Make sure the users who need this feature have the appropriate role assigned."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -18,5 +18,6 @@
   "admin/settings.process-unsent-helptext": "Process all unsent requests to notify and download an XLS file of the results.",
   "admin/settings.verify-availability-helptext": "Runs a shipping simulation to verify that the item can be shipped to the shopper before sending a notificaiton.",
   "admin/settings.marketplace-to-notify-helptext": "Allows a seller account to specify a comma separated list of marketplace account names to notify of inventory updates.",
-  "admin/settings.label": "Settings"
+  "admin/settings.label": "Settings",
+  "admin/settings.permission-warning": "A partir de dd/mm/yyyy, o acesso ao Download Requests e ao Process Unsent exigirá o recurso [resource-name] no License Manager. Certifique-se de que os usuários que precisam dessa funcionalidade tenham a role adequada atribuída."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -19,5 +19,5 @@
   "admin/settings.verify-availability-helptext": "Runs a shipping simulation to verify that the item can be shipped to the shopper before sending a notificaiton.",
   "admin/settings.marketplace-to-notify-helptext": "Allows a seller account to specify a comma separated list of marketplace account names to notify of inventory updates.",
   "admin/settings.label": "Settings",
-  "admin/settings.permission-warning": "A partir de dd/mm/yyyy, o acesso ao Download Requests e ao Process Unsent exigirá o recurso Download Notification Requests no License Manager. Certifique-se de que os usuários que precisam dessa funcionalidade tenham a role adequada atribuída."
+  "admin/settings.permission-warning": "A partir de 21/09/2026, o acesso ao Download Requests e ao Process Unsent exigirá o recurso Download Notification Requests no License Manager. Certifique-se de que os usuários que precisam dessa funcionalidade tenham a role adequada atribuída."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -19,5 +19,5 @@
   "admin/settings.verify-availability-helptext": "Runs a shipping simulation to verify that the item can be shipped to the shopper before sending a notificaiton.",
   "admin/settings.marketplace-to-notify-helptext": "Allows a seller account to specify a comma separated list of marketplace account names to notify of inventory updates.",
   "admin/settings.label": "Settings",
-  "admin/settings.permission-warning": "A partir de dd/mm/yyyy, o acesso ao Download Requests e ao Process Unsent exigirá o recurso [resource-name] no License Manager. Certifique-se de que os usuários que precisam dessa funcionalidade tenham a role adequada atribuída."
+  "admin/settings.permission-warning": "A partir de dd/mm/yyyy, o acesso ao Download Requests e ao Process Unsent exigirá o recurso Download Notification Requests no License Manager. Certifique-se de que os usuários que precisam dessa funcionalidade tenham a role adequada atribuída."
 }

--- a/react/NotifyAdmin.tsx
+++ b/react/NotifyAdmin.tsx
@@ -68,7 +68,7 @@ const messages = defineMessages({
   permissionWarning: {
     id: 'admin/settings.permission-warning',
     defaultMessage:
-      'Starting dd/mm/yyyy, accessing Download Requests and Process Unsent will require the Download Notification Requests resource in License Manager. Make sure the users who need this feature have the appropriate role assigned.',
+      'Starting 09/21/2026, accessing Download Requests and Process Unsent will require the Download Notification Requests resource in License Manager. Make sure the users who need this feature have the appropriate role assigned.',
   },
   downloadHelptext: {
     id: 'admin/settings.download-helptext',

--- a/react/NotifyAdmin.tsx
+++ b/react/NotifyAdmin.tsx
@@ -68,7 +68,7 @@ const messages = defineMessages({
   permissionWarning: {
     id: 'admin/settings.permission-warning',
     defaultMessage:
-      'Starting dd/mm/yyyy, accessing Download Requests and Process Unsent will require the [resource-name] resource in License Manager. Make sure the users who need this feature have the appropriate role assigned.',
+      'Starting dd/mm/yyyy, accessing Download Requests and Process Unsent will require the Download Notification Requests resource in License Manager. Make sure the users who need this feature have the appropriate role assigned.',
   },
   downloadHelptext: {
     id: 'admin/settings.download-helptext',

--- a/react/NotifyAdmin.tsx
+++ b/react/NotifyAdmin.tsx
@@ -4,6 +4,7 @@ import type { FC } from 'react'
 import React, { useState, useEffect } from 'react'
 import { injectIntl, defineMessages } from 'react-intl'
 import {
+  Alert,
   ToastProvider,
   ToastConsumer,
   Layout,
@@ -63,6 +64,11 @@ const messages = defineMessages({
   settingsLabel: {
     id: 'admin/settings.label',
     defaultMessage: 'Settings',
+  },
+  permissionWarning: {
+    id: 'admin/settings.permission-warning',
+    defaultMessage:
+      'Starting dd/mm/yyyy, accessing Download Requests and Process Unsent will require the [resource-name] resource in License Manager. Make sure the users who need this feature have the appropriate role assigned.',
   },
   downloadHelptext: {
     id: 'admin/settings.download-helptext',
@@ -297,6 +303,11 @@ const NotifyAdmin: FC<any> = ({ intl }: Props) => {
             </div>
 
             <div className="bg-muted-5 pa8">
+              <div className="mb5">
+                <Alert type="warning">
+                  {intl.formatMessage(messages.permissionWarning)}
+                </Alert>
+              </div>
               <PageBlock
                 variation="annotated"
                 title={intl.formatMessage(messages.download)}


### PR DESCRIPTION
## Summary

- Adds a warning `Alert` (VTEX Styleguide) in the admin panel above the Download Requests and Process Unsent sections
- Informs users that starting on a date TBD, both actions will require a License Manager resource (name TBD) to be accessible
- Translations added for `en` and `pt`

## Notes

The date and resource name are placeholders (`dd/mm/yyyy` and `[Download Notification Requests]`) and should be updated in `messages/en.json` and `messages/pt.json` before releasing.

## How to test it:

[Workspace](https://availabilitynotify--storecomponents.myvtex.com/admin/availability-notify)

<img width="925" height="385" alt="image" src="https://github.com/user-attachments/assets/f9d1040d-40da-40b5-85e7-b854691ff4df" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)