### PR TITLE
EDU-19164 - Update README.md with BC about Download Notification Requests resource requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
 - Update README for "Download Notification Requests" LM resource requirement (breaking change).
 
 ## [1.14.2] - 2026-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Update README for "Download Notification Requests" LM resource requirement (breaking change).
+
 ## [1.14.2] - 2026-05-05
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,12 +16,12 @@ The app records the notification request and monitors inventory updates. This wa
 
 1. [Install](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-installing-an-app) the Availability Notify app in the desired VTEX account by running `vtex install vtex.availability-notify` in your terminal.
 
-2. Open your store’s Store Theme app directory in your code editor.
+2. Open your store's Store Theme app directory in your code editor.
 
-3. Open your app's `manifest.json file` and add the Availability Notify app under the `peerDependencies` field.
+3. Open your app's `manifest.json` file and add the Availability Notify app under the `peerDependencies` field.
 
     >⚠️ Due to changes in its peer dependencies, you will need to release a new major version. Check the documentation on [How to migrate CMS settings after a theme major update](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-migrating-cms-settings-after-major-update).
-    
+
     ```json
       "peerDependencies": {
         "vtex.availability-notify": "1.x"
@@ -32,62 +32,69 @@ The app records the notification request and monitors inventory updates. This wa
 
     ```json
     {
-     "store.product": {
+      "store.product": {
         "children": [
           "availability-notify"
         ]
       },
+      ...
+    }
     ```
 
-5. Once you have added the `availability-notify` component, access your store's Admin.
-6. Go to **Extensions Hub** > **Installed Apps** > **Availability Notifier**. You can also find it using the search bar at the top of the page.
+5. Once you have added the availability-notify component, access your store's Admin.
+6. Go to **Extensions Hub > Installed Apps > Availability Notify**. You can also find it using the search bar at the top of the page.
 7. Then, you will see the app's settings:
 
-![app-settings](https://user-images.githubusercontent.com/47258865/177632798-1aa3b247-10fe-45e2-93a2-73527c19c0f9.png)
+    ![app-settings](https://user-images.githubusercontent.com/47258865/177632798-1aa3b247-10fe-45e2-93a2-73527c19c0f9.png)
 
-| Setting field           | Description                                                                                                            |
-|-------------------------|------------------------------------------------------------------------------------------------------------------------|
-| `Verify Availability`   | Runs a shipping simulation to verify that the item can be shipped to the shopper before sending a notification.        |
-| `Marketplace to Notify` | Allows a seller account to specify a comma-separated list of marketplace account names to notify of inventory updates. |
-| `Download Requests`     | Download an XLS file of all request records.                                                                          |
-| `Process Unsent`        | Process all unsent requests and download an XLS file of the results.                                                   |
+    | Setting field | Description |
+    | - | - |
+    | Verify Availability | Runs a shipping simulation to verify that the item can be shipped to the shopper before sending a notification. |
+    | Marketplace to Notify | Allows a seller account to specify a comma-separated list of marketplace account names to notify of inventory updates. |
+    | Download Requests | Download an XLS file of all request records. Requires the **Download Notification Requests** [License Manager resource](https://help.vtex.com/docs/tutorials/license-manager-resources). |
+    | Process Unsent | Process all unsent requests and download an XLS file of the results. Requires the **Download Notification Requests** [License Manager resource](https://help.vtex.com/docs/tutorials/license-manager-resources). |
 
 After making the desired settings in the app, set up its template according to your needs. Check out more details about it in the next section, [Customizing the Back in stock template](#customizing-the-back-in-stock-template).
+
+## Required permissions for request management
+
+**Breaking change:** Starting on [September 21st, 2026], **Download Requests**, **Process Unsent**, and deleting notification requests require the **Download Notification Requests** [License Manager resource](https://help.vtex.com/docs/tutorials/license-manager-resources). Users without this resource will see a permission error in Admin and receive HTTP 403 Forbidden from the related APIs. For more details, see the [breaking change announcement](https://help.vtex.com/announcements/2026-08-17-breaking-change-availability-notify-new-mandatory-permission).
 
 ## Seller Configuration
 
 This app also needs to be installed on the seller account.
 
-1. [Install](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-installing-an-app) the Availability Notify app in the desired VTEX SELLER account through the app store
-2. In the app configuration, enter the name of the marketplace to notify when there are any inventory changes
-
-This will forward the inventory change to the MARKETPLACE and then trigger the `Back In Stock` email to the subscribed users of that product.
+1. [Install](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-installing-an-app) the Availability Notify app in the desired VTEX SELLER account through the app store.
+2. In the app configuration, enter the name of the marketplace to notify when there are any inventory changes.
+This will forward the inventory change to the MARKETPLACE and then trigger the Back In Stock email to the subscribed users of that product.
 
 ## Customizing the Back in stock template
 
 Once you have installed the app, you can customize the email template to send to the shoppers who asked to be notified.
 
-1. Find the email template, named **BACK IN STOCK**, in your store's Admin in **Customer** > **Message center** > **Templates**.
-2. Search for the `availability-notify` component template, named **BACK IN STOCK**, and click on it.
+1. Find the email template, named **BACK IN STOCK**, in your store's Admin in **Customer > Message center > Templates**.
+2. Search for the availability-notify component template, named *BACK IN STOCK*, and click on it.
 3. After, you will see the email template and its configuration. For example:
-
 ![template-back-in-stock](https://user-images.githubusercontent.com/67270558/131547198-a4eb3f0e-5a20-4e63-9f1f-d3bb312fa621.gif)
 
 To edit the email template's field, check the documentation on [How to create and edit transactional email templates](https://help.vtex.com/en/tracks/transactional-emails--6IkJwttMw5T84mlY9RifRP/335JZKUYgvYlGOJgvJYxRO), and you will notice the **JSON Data** field, which is responsible for adding variables that allow you to dynamically add data to the email. These variables are JSON properties, and you can see more details about them in [Get SKU and context](https://developers.vtex.com/vtex-rest-api/reference/catalog-api-sku#catalog-api-get-sku-context) and in [Including order variables in email template](https://help.vtex.com/en/tracks/transactional-emails--6IkJwttMw5T84mlY9RifRP/fLMUCPArCYB9vcTZEZ6bi).
-
->⚠️ JSON Data examples will only appear in templates when you complete the desired action in your store. If you have not transacted an order, recurrence, or any other action, the JSON data will appear blank. NOTE: The notification email is only triggered when on the `master` workspace.
+:warning: JSON Data examples will only appear in templates when you complete the desired action in your store. If you have not transacted an order, recurrence, or any other action, the JSON data will appear blank. NOTE: The notification email is only triggered when on the `master` workspace.
 
 ## Searching and processing availability notify data
 
 This app uses [Master Data V2](https://developers.vtex.com/vtex-rest-api/reference/master-data-api-v2-overview), to search for stored data you should use Master Data API - v2 endpoints with the variables `data_entity_name` and `schema` with the value `notify`.
 
-If you want to run the services manually, you can use the two endpoints below: (An authentication token is required)
+If you want to run the services manually, you can use the two endpoints below:
 
-- To process Unsent Requests:
-`https://app.io.vtex.com/vtex.availability-notify/v1/{{accountName}}/master/_v/availability-notify/process-unsent-requests`
+To process Unsent Requests:
 
-- To process All Requests:
-`https://app.io.vtex.com/vtex.availability-notify/v1/{{accountName}}/master/_v/availability-notify/process-all-requests`
+`https://app.io.vtex.com/vtex.availability-notify/v1/{{accountName}}/master/_v/availability-notify/process-unsent-requests`.
+
+To process All Requests:
+
+`https://app.io.vtex.com/vtex.availability-notify/v1/{{accountName}}/master/_v/availability-notify/process-all-requests`.
+
+> ⚠️ To use these endpoints, an [API key](https://help.vtex.com/docs/tutorials/api-keys) is required and it must have the **Download Notification Requests** License Manager resource. For details, see the [breaking change announcement](https://help.vtex.com/announcements/2026-08-17-breaking-change-availability-notify-new-mandatory-permission).
 
 Check out the [Open API Schemas repository](https://github.com/vtex/openapi-schemas) containing several VTEX Postman Collections, including Master Data API - v2.
 


### PR DESCRIPTION
This PR is part of [EDU-19146](https://vtex-dev.atlassian.net/browse/EDU-19164) and complements PRs #106 and #107. It updates the app documentation to reflect the breaking change requiring the **Download Notification Requests** [License Manager resource](https://help.vtex.com/docs/tutorials/license-manager-resources) for managing notification requests.

The affected operations are:
- Download requests (Admin and API)
- Process unset requests (Admin and API)
- Delete requests (API only)

[EDU-19146]: https://vtex-dev.atlassian.net/browse/EDU-19146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ